### PR TITLE
Redid the dolar-in-multiline-literal puzzler with multiple files

### DIFF
--- a/src/syntax/strings/dollarInMultilineLiterals/Rationale.md
+++ b/src/syntax/strings/dollarInMultilineLiterals/Rationale.md
@@ -1,8 +1,8 @@
-Correct answer: **d) Will not compile**
+Correct answer: **g) None of the above**
 
 It is because the *only* special character in a multiline literal is `$`, and it can't be screened. 
 
-If you need a string like `"""$HOME"""` without it resolving to a variable `HOME`, use `${'$'}` instead of `$`. 
+The *only way* to have a string like `"""$HOME"""` without it resolving to a variable `HOME` is to use `${'$'}` instead of `$`. 
 
 An improvment over this is importing `import kotlin.text.Typography.dollar`:
 

--- a/src/syntax/strings/dollarInMultilineLiterals/dollar-in-multiline-literals.kts
+++ b/src/syntax/strings/dollarInMultilineLiterals/dollar-in-multiline-literals.kts
@@ -1,13 +1,18 @@
 package syntax.strings.dollarInMultilineLiterals
 
-val multiline = """
-        To win \$999.999 ececute "rm -fr \$HOME/kotlin-puzzlers/*"
-        """.trimIndent()
+// Which of the following string literals represents a Linux command for deleting $HOME directory?
+// `rm -rf $HOME/*`
 
-println(multiline)
-
-// What will it print?
-// a) To win \$999.999 ececute "rm -fr \$HOME/kotlin-puzzlers/*"
-// b) To win 999.999 ececute "rm -fr \usr/root/kotlin-puzzlers/*"
-// c) To win $999.999 ececute "rm -fr $HOME/kotlin-puzzlers/*"
-// d) Will not compile
+// a)
+val deleteHomeDirA = """ rm -rf $HOME/* """
+// b)
+val deleteHomeDirB = """ rm -rf "$HOME/*" """
+// c)
+val deleteHomeDirC = """ rm -rf \$HOME/* """
+// d)
+val deleteHomeDirD = """ rm -rf $$HOME/* """
+// e)
+val deleteHomeDirE = """ rm -rf `$`HOME/* """
+// f)
+val deleteHomeDirF = """ rm -rf $$\bHOME/* """
+// g) None of the above

--- a/src/syntax/strings/dollarInMultilineLiterals/option-A.kts
+++ b/src/syntax/strings/dollarInMultilineLiterals/option-A.kts
@@ -1,0 +1,8 @@
+package syntax.strings.dollarInMultilineLiterals
+
+// Which of the following string literals would represent a Linux command for deleting $HOME directory?
+// `rm -rf $HOME/*`
+
+// Option A:
+val deleteHomeDirA = """ rm -rf $HOME/* """
+println(deleteHomeDirA)

--- a/src/syntax/strings/dollarInMultilineLiterals/option-B.kts
+++ b/src/syntax/strings/dollarInMultilineLiterals/option-B.kts
@@ -1,0 +1,8 @@
+package syntax.strings.dollarInMultilineLiterals
+
+// Which of the following string literals would represent a Linux command for deleting $HOME directory?
+// `rm -rf $HOME/*`
+
+// Option B:
+val deleteHomeDirB = """ rm -rf "$HOME/*" """
+println(deleteHomeDirB)

--- a/src/syntax/strings/dollarInMultilineLiterals/option-C.kts
+++ b/src/syntax/strings/dollarInMultilineLiterals/option-C.kts
@@ -1,0 +1,8 @@
+package syntax.strings.dollarInMultilineLiterals
+
+// Which of the following string literals would represent a Linux command for deleting $HOME directory?
+// `rm -rf $HOME/*`
+
+// Option C:
+val deleteHomeDirC = """ rm -rf \$HOME/* """
+println(deleteHomeDirC)

--- a/src/syntax/strings/dollarInMultilineLiterals/option-D.kts
+++ b/src/syntax/strings/dollarInMultilineLiterals/option-D.kts
@@ -1,0 +1,8 @@
+package syntax.strings.dollarInMultilineLiterals
+
+// Which of the following string literals would represent a Linux command for deleting $HOME directory?
+// `rm -rf $HOME/*`
+
+// Option D:
+val deleteHomeDirD = """ rm -rf $$HOME/* """
+println(deleteHomeDirD)

--- a/src/syntax/strings/dollarInMultilineLiterals/option-E.kts
+++ b/src/syntax/strings/dollarInMultilineLiterals/option-E.kts
@@ -1,0 +1,8 @@
+package syntax.strings.dollarInMultilineLiterals
+
+// Which of the following string literals would represent a Linux command for deleting $HOME directory?
+// `rm -rf $HOME/*`
+
+// Option E:
+val deleteHomeDirE = """ rm -rf `$`HOME/* """
+println(deleteHomeDirE)

--- a/src/syntax/strings/dollarInMultilineLiterals/option-F.kts
+++ b/src/syntax/strings/dollarInMultilineLiterals/option-F.kts
@@ -1,0 +1,8 @@
+package syntax.strings.dollarInMultilineLiterals
+
+// Which of the following string literals would represent a Linux command for deleting $HOME directory?
+// `rm -rf $HOME/*`
+
+// Option F:
+val deleteHomeDirF = """ rm -rf $$\bHOME/* """
+println(deleteHomeDirF)


### PR DESCRIPTION
Multiple test files are necessary since not all variants compile. The intended use is to show the options, ask what options will at all compile, then check files `option-*.kts` one by one.

One option would be to have a test framework like JUnit to run those files and report the results simultaneously. 