### PR TITLE
fix the typo in unsignedFinally

### DIFF
--- a/src/types/unsignedFinally/Rationale.md
+++ b/src/types/unsignedFinally/Rationale.md
@@ -1,4 +1,4 @@
-Correct answer: **c) 0 4294967294**
+Correct answer: **b) 0 4294967294**
 
 * UInt is an inline class masking a regular Int
 * If you pass an inline class value to an Any parameter, it will get boxed


### PR DESCRIPTION
I found the typo in unsignedFinally/Rationale.md.
```
Correct answer: **c) 0 4294967294**
```

I fixed it.
```
Correct answer: **b) 0 4294967294**
```