### PR TITLE
add extension property delegate puzzlers

### DIFF
--- a/src/delegates/extension/lazyExtension/LazyExtensionProperty.kts
+++ b/src/delegates/extension/lazyExtension/LazyExtensionProperty.kts
@@ -1,0 +1,14 @@
+// by Tobias Berger @tobiberger
+package delegates.extension.lazyExtension
+
+class MyClass(val foo: String)
+
+val MyClass.length by lazy { foo.length.toString() }
+
+println(MyClass("bar").length + MyClass("kotlin").length)
+
+// What will it print?
+// a) 33
+// b) 36
+// b) Lazy value not initialized yet.Lazy value not initialized yet.
+// d) will not compile

--- a/src/delegates/extension/lazyExtension/Rationale.md
+++ b/src/delegates/extension/lazyExtension/Rationale.md
@@ -1,0 +1,6 @@
+Correct answer: **will not compile**
+
+* Extension functions and properties are independent of the receiver instance (like static Java methods)
+* The delegate is an instance that handles getter/setter calls. 
+* For extension properties, this is a single shared delegate instance
+* The extension is initialized independently of any instance, so the delegate can't use any instance properties

--- a/src/delegates/extension/lazyExtension/Rationale.md
+++ b/src/delegates/extension/lazyExtension/Rationale.md
@@ -1,6 +1,23 @@
 Correct answer: **will not compile**
 
-* Extension functions and properties are independent of the receiver instance (like static Java methods)
-* The delegate is an instance that handles getter/setter calls. 
-* For extension properties, this is a single shared delegate instance
-* The extension is initialized independently of any instance, so the delegate can't use any instance properties
+* Extension functions and properties are independent of the receiver object (like static Java methods)
+* The delegate is just an object that handles getter/setter calls. 
+* For extension properties, this is a single shared delegate istance
+* When defining a delegated property inside a class body, it will be initialized as part of the constructor, giving it access to `this` as well as constructor parameters. 
+* When it is defined as an extension property it will be initialized just once while it is loaded. No receiver object is present at that point, so `foo` doesn't exist in that scope.
+
+The issue may become clearer when looking at how delegates work.
+
+This setup
+```
+val MyClass.length by lazy { foo.length.toString() }
+```
+is basically equivalent to this (almost valid syntax)
+```
+val delegate = lazy { foo.length.toString() }
+val MyClass.length
+  get() = delegate.getValue(this, MyClass::length)
+```
+Here you can clearly see that there is no way for the lambda to know what `foo` is.
+
+The `getValue` implementation of `Lazy` ignores the input parameters. It could theoretically use the reference that is passed here to access a receiver object. But you still need to consider that you only have a single delegate object for all receivers (also see [ThisRefExtensionProperty.kts](../thisRef/ThisRefExtensionProperty.kts))

--- a/src/delegates/extension/thisRef/Rationale.md
+++ b/src/delegates/extension/thisRef/Rationale.md
@@ -1,0 +1,6 @@
+Correct answer: **33**
+
+* Extension functions and properties are independent of the receiver instance (like static Java methods)
+* The delegate is an instance that handles getter/setter calls. 
+* For extension properties, this is a single shared delegate instance
+* The value in this single instance is only initialized once and then returns the same result for all receivers

--- a/src/delegates/extension/thisRef/ThisRefExtensionProperty.kts
+++ b/src/delegates/extension/thisRef/ThisRefExtensionProperty.kts
@@ -1,0 +1,29 @@
+// by Tobias Berger @tobiberger
+package delegates.extension.thisRef
+
+import kotlin.reflect.KProperty
+
+class CustomLazy<R: Any, T: Any>(private val initializer: R.() -> T) {
+  private lateinit var value: T
+  private var initialized = false
+
+  operator fun getValue(thisRef: R, property: KProperty<*>): T {
+    if (!initialized) {
+      value = initializer(thisRef)
+      initialized = true
+    }
+    return value
+  }
+}
+
+class MyClass(val foo: String)
+
+val MyClass.length by CustomLazy<MyClass, String> { foo.length.toString() }
+
+println(MyClass("bar").length + MyClass("kotlin").length)
+
+// What will it print?
+// a) 33
+// b) 36
+// b) UninitializedPropertyAccessException
+// d) will not compile


### PR DESCRIPTION
There is something to consider when using extension properties in combination with delegates.
I added 2 different versions of this puzzler that show the issue in slightly different ways. The custom delegate implementation might be a failed try to fix the problem of the other version.