### PR TITLE
Add puzzlers for ConcurrentHashMap and Hashtable.contains(Object)

### DIFF
--- a/src/collections/mapContains/MapContains1.kts
+++ b/src/collections/mapContains/MapContains1.kts
@@ -8,14 +8,14 @@ scores["Rachel"] = 11
 
 val scoresHigherThan10 = scores.filterValues { it > 10 }
 
-scores.contains("Steve")
-scores.contains("Rachel")
+println(scores.contains("Steve"))
+println(scores.contains("Rachel"))
 
-scoresHigherThan10.contains("Steve")
-scoresHigherThan10.contains("Rachel")
+println(scoresHigherThan10.contains("Steve"))
+println(scoresHigherThan10.contains("Rachel"))
 
 // What will the results be?
 // a) true true true true
-// b) false false false false
+// b) true true false false
 // c) false false false true
 // d) true true false true

--- a/src/collections/mapContains/MapContains1.kts
+++ b/src/collections/mapContains/MapContains1.kts
@@ -1,0 +1,21 @@
+package collections.mapContains
+
+import java.util.concurrent.ConcurrentHashMap
+
+val scores = ConcurrentHashMap<String, Int>()
+scores["Steve"] = 9
+scores["Rachel"] = 11
+
+val scoresHigherThan10 = scores.filterValues { it > 10 }
+
+scores.contains("Steve")
+scores.contains("Rachel")
+
+scoresHigherThan10.contains("Steve")
+scoresHigherThan10.contains("Rachel")
+
+// What will the results be?
+// a) true true true true
+// b) false false false false
+// c) false false false true
+// d) true true false true

--- a/src/collections/mapContains/MapContains2.kts
+++ b/src/collections/mapContains/MapContains2.kts
@@ -6,9 +6,9 @@ val friendsMap = Properties()
 friendsMap["John"] = "Jane"
 friendsMap["Jane"] = "Dave"
 
-"John" in friendsMap
-"Jane" in friendsMap
-"Dave" in friendsMap
+println("John" in friendsMap)
+println("Jane" in friendsMap)
+println("Dave" in friendsMap)
 
 // What will the results be?
 // a) true true true

--- a/src/collections/mapContains/MapContains2.kts
+++ b/src/collections/mapContains/MapContains2.kts
@@ -1,0 +1,17 @@
+package collections.mapContains
+
+import java.util.Properties
+
+val friendsMap = Properties()
+friendsMap["John"] = "Jane"
+friendsMap["Jane"] = "Dave"
+
+"John" in friendsMap
+"Jane" in friendsMap
+"Dave" in friendsMap
+
+// What will the results be?
+// a) true true true
+// b) false false false
+// c) true true false
+// d) false true true

--- a/src/collections/mapContains/Rationale1.md
+++ b/src/collections/mapContains/Rationale1.md
@@ -1,0 +1,10 @@
+Correct answer: **c) false false false true**
+
+`java.util.concurrent.ConcurrentHashMap` defines a `contains(Object)` method which checks if a **value** is contained.
+Therefore, the first two calls return `false`.  
+The `filterValues` call is just a decoy; important here is that the result is `Map` and therefore the `contains` calls
+on it resolves to the Kotlin extension function `Map<K, V>.contains(K)`, as expected.
+
+This came up [here](https://github.com/google/gson/issues/1773) where this behavior mismatch caused confusion.
+
+[JDK-8268665](https://bugs.openjdk.java.net/browse/JDK-8268665) requests to deprecate this misleading `contains` method.

--- a/src/collections/mapContains/Rationale2.md
+++ b/src/collections/mapContains/Rationale2.md
@@ -1,0 +1,12 @@
+Correct answer: **d) false true true**
+
+`java.util.Hashtable` (and its subclass `Properties`) defines a `contains(Object)` method which checks if a **value**
+is contained. Therefore, Kotlin's `in` operator uses that method instead of the Kotlin extension function
+`Map<K, V>.contains(K)`.
+
+This has been reported as [KT-48007](https://youtrack.jetbrains.com/issue/KT-48007);
+the same issue for `ConcurrentHashMap` has been fixed in the past, see [KT-18053](https://youtrack.jetbrains.com/issue/KT-18053).
+For that class the compiler emits an error when `in` is used.
+
+The fact that `Hashtable.contains(Object)` behaves counterintuitively was also used as puzzle in
+["Java Puzzlers, Strange Loop Edition" by Bob Lee and Josh Bloch (2013)](https://youtu.be/qRTIpyd_snc?t=63).


### PR DESCRIPTION
Add puzzlers for the counterintuitive behavior of `ConcurrentHashMap` and `Hashtable` (respectively its subclass `Properties`) `contains(Object)` which checks if a **value** is contained.

- Puzzler 1 is about the conflict with the `Map.contains(K)` extension function
- Puzzler 2 is about its interaction with the `in` operator
