### PR TITLE
Add puzzler for Iterable.joinToString parameter confusion

### DIFF
--- a/src/syntax/functionParameterConfusion/FunctionParameterConfusion.kts
+++ b/src/syntax/functionParameterConfusion/FunctionParameterConfusion.kts
@@ -1,0 +1,11 @@
+package syntax.functionParameterConfusion
+
+val items = listOf("a", null, "b")
+
+println(items.joinToString { " + " })
+
+// What will the output be?
+// a) null
+// b) " + , + , + "
+// c) "a, null, b"
+// d) "a + null + b"

--- a/src/syntax/functionParameterConfusion/FunctionParameterConfusion.kts
+++ b/src/syntax/functionParameterConfusion/FunctionParameterConfusion.kts
@@ -1,11 +1,11 @@
 package syntax.functionParameterConfusion
 
-val items = listOf("a", null, "b")
+val items = listOf("a", "b", "c")
 
 println(items.joinToString { " + " })
 
 // What will the output be?
-// a) null
-// b) " + , + , + "
-// c) "a, null, b"
-// d) "a + null + b"
+// a) "a + b + c"
+// b) "a b c"
+// c) "a, b, c"
+// d) None of the above

--- a/src/syntax/functionParameterConfusion/Rationale.md
+++ b/src/syntax/functionParameterConfusion/Rationale.md
@@ -1,0 +1,9 @@
+Correct answer: **b) " + , + , + "**
+
+`joinToString` has a default argument for every parameter, including the _separator_. The code uses curly brackets
+(`{ ... }`) which therefore represents the _transform_ function, transforming every element. The parameter of the
+transform function was omitted.
+
+The lesson from this: Pay attention to the difference between parentheses and curly brackets and verify that you are
+passing a value for the correct parameter. Also be careful when using suggestions from the IDE, here IntelliJ IDEA
+would have suggested the variant with _transform_ function first.

--- a/src/syntax/functionParameterConfusion/Rationale.md
+++ b/src/syntax/functionParameterConfusion/Rationale.md
@@ -1,8 +1,8 @@
-Correct answer: **b) " + , + , + "**
+Correct answer: **d) None of the above** - the created string is actually `" + , + , + "`
 
 `joinToString` has a default argument for every parameter, including the _separator_. The code uses curly brackets
-(`{ ... }`) which therefore represents the _transform_ function, transforming every element. The parameter of the
-transform function was omitted.
+(`{ ... }`) which therefore represents the _transform_ function, transforming every element. The parameter (`it`) of
+the transform function was omitted.
 
 The lesson from this: Pay attention to the difference between parentheses and curly brackets and verify that you are
 passing a value for the correct parameter. Also be careful when using suggestions from the IDE, here IntelliJ IDEA

--- a/src/syntax/gameOfLife/Rationale.md
+++ b/src/syntax/gameOfLife/Rationale.md
@@ -1,6 +1,6 @@
 Correct answer: **b) 3**
 
-* Languges without semicolons need to make decisions when a statement ends
+* Languages without semicolons need to make decisions when a statement ends
   * Lines starting with '+' can be interpreted as starting with unary '+'
   * Groovy has the same problem, but JavaScript hasn't
   * Fix by keeping '+' on the previous line


### PR DESCRIPTION
Adds a puzzler for a call to `joinToString` where by accident a _transform_ function was provided instead of a _separator_.

Not sure if this is a good puzzler, feedback is appreciated.