### PR TITLE
Add bitwise shift puzzler

### DIFF
--- a/src/operators/bitwiseShift/BitwiseShift.kts
+++ b/src/operators/bitwiseShift/BitwiseShift.kts
@@ -1,0 +1,15 @@
+package operators.bitwiseShift
+
+var result: Int = 0
+
+for (i in 0..32) {
+  result += (1 shl i)
+}
+
+println(result)
+
+// What will it print?
+// a) 2147483647 (Int.MAX_VALUE)
+// b) 0
+// c) -1
+// d) -2147483648 (Int.MIN_VALUE)

--- a/src/operators/bitwiseShift/Rationale.md
+++ b/src/operators/bitwiseShift/Rationale.md
@@ -1,0 +1,10 @@
+Correct answer: **b) 0**
+
+The loop first iteratively sets all the bits of the `result` signed `Int`. When all bits are set `result` will
+therefore have the value `-1`. However, the range over which the loop iterates actually includes `32`. And similar to
+Java's bitwise shift operators, Kotlin's `shl`, `shr` and `ushr` actually only use the lowest 5 bits of the shift
+distance:
+> Note that only the five lowest-order bits of the bitCount are used as the shift distance. The shift distance
+> actually used is therefore always in the range 0..31.
+
+That is why, opposed to what one might expect, `1 shl 32` results in 1, and `-1 + 1 = 0`.


### PR DESCRIPTION
Adds a puzzler for the `shl` bitwise operator, exploiting the fact that, like Java's bitwise operators, only the lowest 5 bits of the shift distance are considered.